### PR TITLE
feat: 공통 응답 포멧, 에러 핸들링 추가

### DIFF
--- a/src/common/exceptions/custom.exception.ts
+++ b/src/common/exceptions/custom.exception.ts
@@ -1,0 +1,14 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+interface CustomExceptionResponse {
+  message: string;
+  code: string;
+  meta?: Record<string, unknown>;
+}
+
+export class CustomException extends HttpException {
+  constructor(message: string, code: string, meta?: Record<string, unknown>) {
+    const response: CustomExceptionResponse = { message, code, meta };
+    super(response, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/common/exceptions/custom.exception.ts
+++ b/src/common/exceptions/custom.exception.ts
@@ -2,13 +2,21 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 
 interface CustomExceptionResponse {
   message: string;
-  code: string;
+  errorCode: string;
   meta?: Record<string, unknown>;
 }
 
 export class CustomException extends HttpException {
-  constructor(message: string, code: string, meta?: Record<string, unknown>) {
-    const response: CustomExceptionResponse = { message, code, meta };
+  constructor(
+    message: string,
+    errorCode: string,
+    meta?: Record<string, unknown>,
+  ) {
+    const response: CustomExceptionResponse = {
+      message,
+      errorCode,
+      meta,
+    };
     super(response, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/filters/http-exception.filter.spec.ts
+++ b/src/filters/http-exception.filter.spec.ts
@@ -1,0 +1,57 @@
+import { ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+
+import { HttpExceptionFilter } from './http-exception.filter';
+
+describe('HttpExceptionFilter', () => {
+  let filter: HttpExceptionFilter;
+
+  beforeEach(() => {
+    filter = new HttpExceptionFilter();
+  });
+
+  it('HttpException을 포맷에 맞게 변환하여 응답해야 함', () => {
+    const mockJson = jest.fn();
+    const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+
+    const mockResponse = {
+      status: mockStatus,
+    };
+
+    const mockRequest = {
+      url: '/test-path',
+    };
+
+    const mockHost = {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse,
+        getRequest: () => mockRequest,
+      }),
+    } as unknown as ArgumentsHost;
+
+    const exception = new HttpException(
+      {
+        message: '에러 메시지입니다.',
+        errorCode: 'SAMPLE_CODE',
+        meta: { sample: true },
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+
+    filter.catch(exception, mockHost);
+
+    expect(mockStatus).toBeCalledWith(HttpStatus.BAD_REQUEST);
+    expect(mockJson).toBeCalledWith({
+      success: false,
+      statusCode: 400,
+      data: {
+        message: '에러 메시지입니다.',
+        path: '/test-path',
+        timestamp: expect.stringMatching(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+        ) as unknown as string,
+        code: 'SAMPLE_CODE',
+        meta: { sample: true },
+      },
+    });
+  });
+});

--- a/src/filters/http-exception.filter.ts
+++ b/src/filters/http-exception.filter.ts
@@ -1,0 +1,77 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+interface ErrorBody {
+  message: string;
+  path: string;
+  timestamp: string;
+  code?: string;
+  meta?: Record<string, unknown>;
+}
+
+interface FailureResponse {
+  success: false;
+  statusCode: number;
+  data: ErrorBody;
+}
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = '서버 내부 오류가 발생했습니다.';
+    let code: string | undefined;
+    let meta: Record<string, unknown> | undefined;
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus();
+
+      const res = exception.getResponse();
+
+      if (typeof res === 'string') {
+        message = res;
+      } else if (typeof res === 'object' && res !== null) {
+        const responseObj = res as {
+          message?: string | string[];
+          code?: string;
+          meta?: Record<string, unknown>;
+        };
+
+        if (Array.isArray(responseObj.message)) {
+          message = responseObj.message.join(', ');
+        } else if (typeof responseObj.message === 'string') {
+          message = responseObj.message;
+        }
+
+        code = responseObj.code;
+        meta = responseObj.meta;
+      }
+    }
+
+    const errorBody: ErrorBody = {
+      message,
+      path: request.url,
+      timestamp: new Date().toISOString(),
+      ...(code ? { code } : {}),
+      ...(meta ? { meta } : {}),
+    };
+
+    const errorResponse: FailureResponse = {
+      success: false,
+      statusCode: status,
+      data: errorBody,
+    };
+
+    response.status(status).json(errorResponse);
+  }
+}

--- a/src/filters/http-exception.filter.ts
+++ b/src/filters/http-exception.filter.ts
@@ -36,14 +36,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
     if (exception instanceof HttpException) {
       status = exception.getStatus();
 
-      const res = exception.getResponse();
+      const exceptionResponse = exception.getResponse();
 
-      if (typeof res === 'string') {
-        message = res;
-      } else if (typeof res === 'object' && res !== null) {
-        const responseObj = res as {
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+      } else if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null
+      ) {
+        const responseObj = exceptionResponse as {
           message?: string | string[];
-          code?: string;
+          errorCode?: string;
           meta?: Record<string, unknown>;
         };
 
@@ -53,7 +56,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
           message = responseObj.message;
         }
 
-        code = responseObj.code;
+        code = responseObj.errorCode;
         meta = responseObj.meta;
       }
     }

--- a/src/interceptors/response.interceptor.spec.ts
+++ b/src/interceptors/response.interceptor.spec.ts
@@ -1,0 +1,33 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { of } from 'rxjs';
+
+import { ResponseInterceptor } from './response.interceptor';
+
+describe('ResponseInterceptor', () => {
+  let interceptor: ResponseInterceptor<any>;
+
+  beforeEach(() => {
+    interceptor = new ResponseInterceptor<any>();
+  });
+
+  it('성공 응답을 { success: true, statusCode: number, data } 형태로 변환해야 함', (done) => {
+    const mockContext = {
+      switchToHttp: () => ({
+        getResponse: () => ({ statusCode: 200 }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler: CallHandler = {
+      handle: () => of('응답값'),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe((result) => {
+      expect(result).toEqual({
+        success: true,
+        statusCode: 200,
+        data: '응답값',
+      });
+      done();
+    });
+  });
+});

--- a/src/interceptors/response.interceptor.ts
+++ b/src/interceptors/response.interceptor.ts
@@ -1,0 +1,36 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+interface SuccessResponse<T> {
+  success: true;
+  statusCode: number;
+  data: T;
+}
+
+@Injectable()
+export class ResponseInterceptor<T>
+  implements NestInterceptor<T, SuccessResponse<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<SuccessResponse<T>> {
+    const ctx = context.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    return next.handle().pipe(
+      map((data: T) => ({
+        success: true,
+        statusCode: response.statusCode ?? 200,
+        data,
+      })),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 
 import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './filters/http-exception.filter';
+import { ResponseInterceptor } from './interceptors/response.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 4000);
+
+  app.useGlobalInterceptors(new ResponseInterceptor());
+  app.useGlobalFilters(new HttpExceptionFilter());
+
+  const port = process.env.PORT || 4000;
+  await app.listen(port);
 }
 void bootstrap();


### PR DESCRIPTION
## 🔍 Overview

- 모든 API 응답에 대해 `{ success, statusCode, data }` 구조로 통일된 포맷을 적용
- 성공과 실패 응답 모두 일관된 형태로 가공되며, 커스텀 예외도 지원

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 📸 Screenshots

- 성공
![image](https://github.com/user-attachments/assets/e4690495-0019-4de0-b059-edcfcc435cb9)

- 실패 (404)
![image](https://github.com/user-attachments/assets/7327cfa4-e7d0-4edf-bc98-7ee9bb692940)

- 실패 (커스텀)
![image](https://github.com/user-attachments/assets/a2af0df3-c225-48cd-840e-645547f7e3fb)


## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

- `ResponseInterceptor`: 성공 응답 포맷 처리
- `HttpExceptionFilter`: 실패 응답 포맷 처리
- 실패 응답의 `data` 내부에 `message`, `code`, `meta`, `path`, `timestamp` 포함
- 커스텀 에러처리 예시
```ts
import { CustomException } from './common/exceptions/custom.exception';

throw new CustomException(
  '이메일 형식이 올바르지 않습니다.',
  'INVALID_EMAIL',
  { field: 'email' },
);
```