### PR TITLE
feat: About Category 모듈 생성 및 등록/조회/수정 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 import { DbModule } from '@/db/db.module';
+import { AboutCategoryModule } from '@/modules/about/category/about-category.module';
 import { HealthModule } from '@/modules/health/health.module';
 import { HelloModule } from '@/modules/hello/hello.module';
 import { UserModule } from '@/modules/user/user.module';
@@ -36,6 +37,7 @@ import { UserModule } from '@/modules/user/user.module';
       ],
     }),
     DbModule,
+    AboutCategoryModule,
     HealthModule,
     HelloModule,
     UserModule,

--- a/src/common/constants/about.enum.ts
+++ b/src/common/constants/about.enum.ts
@@ -1,0 +1,16 @@
+export enum AboutCategoryType {
+  TAB = 'tab',
+  MENU = 'menu',
+}
+
+export enum MenuKey {
+  EXPERIENCE = 'experience',
+  HARD_SKILLS = 'hard-skills',
+  SOFT_SKILLS = 'soft-skills',
+  BIO = 'bio',
+  INTERESTS = 'interests',
+  EDUCATION = 'education',
+  SPORTS = 'sports',
+  FAVORITE_GAMES = 'favorite-games',
+  FAVORITE_FOODS = 'favorite-foods',
+}

--- a/src/modules/about/category/about-category.controller.spec.ts
+++ b/src/modules/about/category/about-category.controller.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AboutCategoryController } from './about-category.controller';
+import { AboutCategoryService } from './about-category.service';
+import { CreateAboutCategoryDto } from './dto/create-about-category.dto';
+import { UpdateAboutCategoryDto } from './dto/update-about-category.dto';
+
+import { AboutCategoryType, MenuKey } from '@/common/constants/about.enum';
+import { LangType } from '@/common/constants/lang-type.enum';
+
+describe('AboutCategoryController', () => {
+  let controller: AboutCategoryController;
+
+  const KEY = 'professional';
+
+  const mockResponse = {
+    id: 'uuid-1234',
+    type: AboutCategoryType.TAB,
+    key: KEY,
+    name: '직무 경험',
+    menus: [MenuKey.EXPERIENCE, MenuKey.HARD_SKILLS, MenuKey.SOFT_SKILLS],
+    displayOrder: 1,
+  };
+
+  const mockService = {
+    create: jest.fn().mockResolvedValue(mockResponse),
+    findAllByLang: jest.fn().mockResolvedValue([mockResponse]),
+    updateByKey: jest.fn().mockResolvedValue(mockResponse),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AboutCategoryController],
+      providers: [{ provide: AboutCategoryService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<AboutCategoryController>(AboutCategoryController);
+  });
+
+  it('AboutCategoryController가 정의되어야 함', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create()', () => {
+    it('새 카테고리를 등록해야 함', async () => {
+      const dto: CreateAboutCategoryDto = {
+        type: AboutCategoryType.TAB,
+        key: KEY,
+        name: { ko: '직무 경험', en: 'experience' },
+        menus: [MenuKey.EXPERIENCE, MenuKey.HARD_SKILLS, MenuKey.SOFT_SKILLS],
+      };
+      const result = await controller.create(dto);
+      expect(result).toEqual(mockResponse);
+      expect(mockService.create).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('findAllByLang()', () => {
+    it('언어 기준으로 카테고리 목록을 조회해야 함', async () => {
+      const lang = 'ko';
+      const result = await controller.findAllByLang(lang as LangType);
+      expect(result).toEqual([mockResponse]);
+      expect(mockService.findAllByLang).toHaveBeenCalledWith(lang);
+    });
+  });
+
+  describe('update()', () => {
+    it('기존 카테고리를 수정해야 함', async () => {
+      const dto: UpdateAboutCategoryDto = {
+        type: AboutCategoryType.TAB,
+        name: { ko: '직무 경험', en: 'experience' },
+        menus: [MenuKey.HARD_SKILLS, MenuKey.SOFT_SKILLS],
+        displayOrder: 1,
+      };
+      const result = await controller.update(MenuKey.EXPERIENCE, dto);
+      expect(result).toEqual(mockResponse);
+      expect(mockService.updateByKey).toHaveBeenCalledWith(
+        MenuKey.EXPERIENCE,
+        dto,
+      );
+    });
+  });
+});

--- a/src/modules/about/category/about-category.controller.ts
+++ b/src/modules/about/category/about-category.controller.ts
@@ -1,0 +1,105 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  Post,
+  Put,
+  Param,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+
+import { AboutCategoryService } from './about-category.service';
+import { AboutCategoryResponseDto } from './dto/about-category-response.dto';
+import { CreateAboutCategoryDto } from './dto/create-about-category.dto';
+import { UpdateAboutCategoryDto } from './dto/update-about-category.dto';
+
+import { MenuKey } from '@/common/constants/about.enum';
+import { LangType } from '@/common/constants/lang-type.enum';
+
+@ApiTags('AboutCategory')
+@Controller('about/category')
+export class AboutCategoryController {
+  constructor(private readonly aboutCategoryService: AboutCategoryService) {}
+
+  @Post()
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'About 카테고리 등록',
+    description: 'About 페이지의 카테고리(tab, menu)를 등록합니다.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: '카테고리 등록 성공',
+    type: AboutCategoryResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '요청 값 오류' })
+  @ApiResponse({ status: 409, description: '중복된 key/type 조합 존재' })
+  @ApiResponse({ status: 500, description: '서버 내부 오류' })
+  create(
+    @Body() dto: CreateAboutCategoryDto,
+  ): Promise<AboutCategoryResponseDto> {
+    return this.aboutCategoryService.create(dto);
+  }
+
+  @Get()
+  @Throttle({ default: { limit: 20, ttl: 10_000 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'About 카테고리 목록 조회',
+    description: '등록된 About 카테고리 목록을 언어(lang) 기준으로 조회합니다.',
+  })
+  @ApiParam({
+    name: 'lang',
+    description: 'ko 또는 en',
+    example: 'ko',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '카테고리 조회 성공',
+    type: AboutCategoryResponseDto,
+    isArray: true,
+  })
+  @ApiResponse({ status: 400, description: 'lang 값 오류' })
+  @ApiResponse({ status: 500, description: '서버 내부 오류' })
+  findAllByLang(
+    @Query('lang') lang: LangType,
+  ): Promise<AboutCategoryResponseDto[]> {
+    return this.aboutCategoryService.findAllByLang(lang);
+  }
+
+  @Put(':key')
+  @Throttle({ medium: { limit: 20, ttl: 10000 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'About Category 수정',
+    description:
+      'key 값을 기준으로 About Category 정보를 수정합니다. **(type은 수정 불가합니다. 기존 값을 그대로 보내주세요.)**',
+  })
+  @ApiParam({
+    name: 'key',
+    description: 'About Category 고유 키',
+    enum: MenuKey,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '수정 성공',
+    type: AboutCategoryResponseDto,
+  })
+  @ApiResponse({ status: 400, description: '유효하지 않은 요청 형식' })
+  @ApiResponse({
+    status: 404,
+    description: '해당 key를 가진 카테고리가 존재하지 않음',
+  })
+  @ApiResponse({ status: 500, description: '서버 내부 오류' })
+  update(
+    @Param('key') key: MenuKey,
+    @Body() dto: UpdateAboutCategoryDto,
+  ): Promise<AboutCategoryResponseDto> {
+    return this.aboutCategoryService.updateByKey(key, dto);
+  }
+}

--- a/src/modules/about/category/about-category.controller.ts
+++ b/src/modules/about/category/about-category.controller.ts
@@ -9,7 +9,13 @@ import {
   Put,
   Param,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 
 import { AboutCategoryService } from './about-category.service';
@@ -53,7 +59,7 @@ export class AboutCategoryController {
     summary: 'About 카테고리 목록 조회',
     description: '등록된 About 카테고리 목록을 언어(lang) 기준으로 조회합니다.',
   })
-  @ApiParam({
+  @ApiQuery({
     name: 'lang',
     description: 'ko 또는 en',
     example: 'ko',

--- a/src/modules/about/category/about-category.module.ts
+++ b/src/modules/about/category/about-category.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AboutCategoryController } from './about-category.controller';
+import { AboutCategoryService } from './about-category.service';
+import { AboutCategory } from './entities/about-category.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AboutCategory])],
+  controllers: [AboutCategoryController],
+  providers: [AboutCategoryService],
+})
+export class AboutCategoryModule {}

--- a/src/modules/about/category/about-category.service.ts
+++ b/src/modules/about/category/about-category.service.ts
@@ -58,7 +58,7 @@ export class AboutCategoryService {
     return {
       ...saved,
       key: saved.key as MenuKey,
-      name: JSON.stringify(saved.name),
+      name: saved.name.ko,
     };
   }
 
@@ -138,7 +138,7 @@ export class AboutCategoryService {
       ...saved,
       type: found.type,
       key: found.key as MenuKey,
-      name: JSON.stringify(saved.name),
+      name: saved.name.ko,
     };
   }
 }

--- a/src/modules/about/category/about-category.service.ts
+++ b/src/modules/about/category/about-category.service.ts
@@ -1,0 +1,144 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { AboutCategoryResponseDto } from './dto/about-category-response.dto';
+import { CreateAboutCategoryDto } from './dto/create-about-category.dto';
+import { UpdateAboutCategoryDto } from './dto/update-about-category.dto';
+import { AboutCategory } from './entities/about-category.entity';
+
+import { AboutCategoryType, MenuKey } from '@/common/constants/about.enum';
+import { ErrorCode } from '@/common/constants/error-code.enum';
+import { LangType } from '@/common/constants/lang-type.enum';
+import { CustomException } from '@/common/exceptions/custom.exception';
+
+@Injectable()
+export class AboutCategoryService {
+  constructor(
+    @InjectRepository(AboutCategory)
+    private readonly aboutCategoryRepository: Repository<AboutCategory>,
+  ) {}
+
+  async create(dto: CreateAboutCategoryDto): Promise<AboutCategoryResponseDto> {
+    const found = await this.aboutCategoryRepository.findOneBy({
+      key: dto.key,
+    });
+
+    if (found) {
+      throw new CustomException(
+        `'${dto.key}' key already exists.`,
+        ErrorCode.DUPLICATE_ERROR,
+      );
+    }
+
+    if (dto.type === AboutCategoryType.MENU && dto.menus) {
+      throw new CustomException(
+        `MENU type must not have 'menus' field.`,
+        ErrorCode.VALIDATION_ERROR,
+      );
+    }
+
+    let displayOrder = dto.displayOrder;
+
+    if (displayOrder === undefined) {
+      const maxOrder = await this.aboutCategoryRepository
+        .createQueryBuilder('category')
+        .select('MAX(category.displayOrder)', 'max')
+        .getRawOne<{ max: number }>();
+      displayOrder = (maxOrder?.max ?? 0) + 1;
+    }
+
+    const created = this.aboutCategoryRepository.create({
+      ...dto,
+      displayOrder,
+    });
+
+    const saved = await this.aboutCategoryRepository.save(created);
+
+    return {
+      ...saved,
+      key: saved.key as MenuKey,
+      name: JSON.stringify(saved.name),
+    };
+  }
+
+  async findAllByLang(lang: LangType): Promise<AboutCategoryResponseDto[]> {
+    if (!Object.values(LangType).includes(lang)) {
+      throw new CustomException(
+        `'${lang}' is not a supported language.`,
+        ErrorCode.VALIDATION_ERROR,
+        {
+          fieldErrors: [
+            {
+              field: 'lang',
+              message: 'Supported languages: ko, en',
+            },
+          ],
+        },
+        400,
+      );
+    }
+
+    const all = await this.aboutCategoryRepository.find({
+      order: { displayOrder: 'ASC' },
+    });
+
+    return all.map((item) => ({
+      id: item.id,
+      type: item.type,
+      key: item.key as MenuKey,
+      name: item.name[lang],
+      menus: item.menus,
+      displayOrder: item.displayOrder,
+    }));
+  }
+
+  async updateByKey(
+    key: MenuKey,
+    dto: UpdateAboutCategoryDto,
+  ): Promise<AboutCategoryResponseDto> {
+    const found = await this.aboutCategoryRepository.findOneBy({ key });
+
+    if (!found) {
+      throw new CustomException(
+        `Category with key '${key}' does not exist.`,
+        ErrorCode.NOTFOUND_ERROR,
+        {
+          fieldErrors: [
+            {
+              param: 'key',
+              message: 'No category found to update for the given key.',
+            },
+          ],
+        },
+        404,
+      );
+    }
+
+    if (dto.type !== found.type) {
+      throw new CustomException(
+        'Cannot update the `type` field.',
+        ErrorCode.VALIDATION_ERROR,
+        {
+          fieldErrors: [
+            {
+              param: 'type',
+              message: 'Cannot update the `type` field.',
+            },
+          ],
+        },
+        400,
+      );
+    }
+
+    const updated = this.aboutCategoryRepository.merge(found, dto);
+    const saved = await this.aboutCategoryRepository.save(updated);
+
+    return {
+      ...saved,
+      type: found.type,
+      key: found.key as MenuKey,
+      name: JSON.stringify(saved.name),
+    };
+  }
+}

--- a/src/modules/about/category/dto/about-category-response.dto.ts
+++ b/src/modules/about/category/dto/about-category-response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { AboutCategoryType, MenuKey } from '@/common/constants/about.enum';
+
+export class AboutCategoryResponseDto {
+  @ApiProperty({ description: 'UUID 형식의 고유 ID', example: 'uuid-1234' })
+  id: string;
+
+  @ApiProperty({
+    description: '카테고리 유형 (tab 또는 menu)',
+    enum: AboutCategoryType,
+  })
+  type: AboutCategoryType;
+
+  @ApiProperty({
+    description: '카테고리 키 (고유값)',
+    enum: MenuKey,
+  })
+  key: MenuKey;
+
+  @ApiProperty({
+    description: 'tab 또는 menu 이름',
+    example: '경력',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'TAB 타입일 경우, 포함된 메뉴 key 리스트',
+    required: false,
+    type: [String],
+    enum: MenuKey,
+  })
+  menus: MenuKey[] | null;
+
+  @ApiProperty({
+    description: '정렬 순서를 위한 숫자 값',
+    example: 1,
+  })
+  displayOrder: number;
+}

--- a/src/modules/about/category/dto/create-about-category.dto.ts
+++ b/src/modules/about/category/dto/create-about-category.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsInt,
+  Min,
+  ValidateIf,
+  Max,
+} from 'class-validator';
+
+import { AboutCategoryType, MenuKey } from '@/common/constants/about.enum';
+
+export class CreateAboutCategoryDto {
+  @ApiProperty({ example: 'professional', description: '카테고리 키 (고유값)' })
+  @IsString()
+  @IsNotEmpty()
+  key: string;
+
+  @ApiProperty({
+    description: '카테고리 유형 (tab 또는 menu)',
+    enum: AboutCategoryType,
+    example: AboutCategoryType.TAB,
+  })
+  @IsEnum(AboutCategoryType)
+  type: AboutCategoryType;
+
+  @ApiProperty({
+    description: '언어별 이름 (ko, en)',
+    example: { ko: '경력', en: 'professional' },
+  })
+  @IsNotEmpty()
+  name: {
+    ko: string;
+    en: string;
+  };
+
+  @ValidateIf((o: CreateAboutCategoryDto) => o.type === AboutCategoryType.TAB)
+  @ApiProperty({
+    description:
+      'TAB 타입일 경우, 포함된 메뉴 key 리스트 (menu 타입의 key만 허용)',
+    example: ['experience', 'hard-skills', 'soft-skills'],
+    required: false,
+    isArray: true,
+    enum: MenuKey,
+    enumName: 'MenuKey',
+  })
+  @IsEnum(MenuKey, { each: true })
+  menus: MenuKey[] | null;
+
+  @ApiProperty({
+    description: '정렬 순서를 위한 숫자 값',
+    example: 1,
+  })
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  @IsOptional()
+  displayOrder?: number;
+}

--- a/src/modules/about/category/dto/update-about-category.dto.ts
+++ b/src/modules/about/category/dto/update-about-category.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsOptional, ValidateIf } from 'class-validator';
+
+import { AboutCategoryType, MenuKey } from '@/common/constants/about.enum';
+
+export class UpdateAboutCategoryDto {
+  @ApiProperty({
+    description:
+      '카테고리 유형 (tab 또는 menu). **type은 수정 불가능합니다. 기존 값을 그대로 보내주세요.**',
+    enum: AboutCategoryType,
+  })
+  @IsEnum(AboutCategoryType)
+  type: AboutCategoryType;
+
+  @ApiProperty({
+    description: '언어별 이름 (ko, en)',
+    example: { ko: '경력', en: 'professional' },
+  })
+  @IsNotEmpty()
+  name: { ko: string; en: string };
+
+  @ValidateIf((o: UpdateAboutCategoryDto) => o.type === AboutCategoryType.TAB)
+  @ApiProperty({
+    description:
+      'TAB 타입일 경우, 포함된 메뉴 key 리스트 (menu 타입의 key만 허용)',
+    example: ['experience', 'hard-skills', 'soft-skills'],
+    required: false,
+    isArray: true,
+    enum: MenuKey,
+    enumName: 'MenuKey',
+  })
+  @IsEnum(MenuKey, { each: true })
+  menus: MenuKey[] | null;
+
+  @ApiProperty({
+    description: '정렬 순서를 위한 숫자 값',
+    example: 1,
+    required: false,
+  })
+  @IsOptional()
+  displayOrder?: number;
+}

--- a/src/modules/about/category/entities/about-category.entity.ts
+++ b/src/modules/about/category/entities/about-category.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+import { AboutCategoryType, MenuKey } from '@/common/constants/about.enum';
+
+@Entity({ name: 'about_category' })
+export class AboutCategory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: AboutCategoryType })
+  type: AboutCategoryType;
+
+  @Column({ unique: true })
+  key: string;
+
+  @Column({ type: 'jsonb' })
+  name: {
+    ko: string;
+    en: string;
+  };
+
+  @Column({ type: 'jsonb', nullable: true })
+  menus: MenuKey[] | null;
+
+  @Column({ type: 'int', default: 0 })
+  displayOrder: number;
+}

--- a/src/modules/hello/hello.service.ts
+++ b/src/modules/hello/hello.service.ts
@@ -22,7 +22,7 @@ export class HelloService {
 
     if (found) {
       throw new CustomException(
-        `Data for language '${dto.lang}' already exists.`,
+        `'${dto.lang}' lang already exists.`,
         ErrorCode.DUPLICATE_ERROR,
       );
     }


### PR DESCRIPTION
## 🔍 Overview

<!-- Briefly describe what this PR does -->
- About Category 모듈 생성 및 등록/조회/수정 API를 구현

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->
- About Category 등록 API (`POST /about/category`)
- About Category 목록 조회 API (`GET /about/category?lang=ko`)
- About Category 수정 API (`PUT /about/category/:key`)
- enum 통합 및 정리 (`AboutCategoryType`, `MenuKey`)
- AboutCategoryController 유닛 테스트 작성