### PR TITLE
feat: Career 서비스 toResponseDto 적용 및 단일 → 목록 조회 변경

### DIFF
--- a/src/modules/career/career.controller.spec.ts
+++ b/src/modules/career/career.controller.spec.ts
@@ -50,8 +50,8 @@ describe('CareerController', () => {
               }
               return Promise.resolve(mockCareerResponse);
             }),
-            findOneByLang: jest.fn().mockResolvedValue(mockCareerResponse),
             updateByKeyAndLang: jest.fn().mockResolvedValue(mockCareerResponse),
+            findByLang: jest.fn().mockResolvedValue([mockCareerResponse]),
           },
         },
       ],
@@ -101,12 +101,6 @@ describe('CareerController', () => {
     expect(service.create).toHaveBeenCalledWith(dto);
   });
 
-  it('경력 단일 조회 성공', async () => {
-    const result = await controller.findOneByLang('ko' as LangType);
-    expect(result).toEqual(mockCareerResponse);
-    expect(service.findOneByLang).toHaveBeenCalledWith('ko');
-  });
-
   it('경력 수정 성공', async () => {
     const dto: UpdateCareerDto = {
       name: '수정된 이름',
@@ -151,5 +145,12 @@ describe('CareerController', () => {
       'ko',
       dto,
     );
+  });
+
+  it('경력 조회 성공', async () => {
+    (service.findByLang as jest.Mock).mockResolvedValue([mockCareerResponse]);
+    const result = await controller.findByLang('ko' as LangType);
+    expect(result).toEqual([mockCareerResponse]);
+    expect(service.findByLang).toHaveBeenCalledWith('ko');
   });
 });

--- a/src/modules/career/career.controller.ts
+++ b/src/modules/career/career.controller.ts
@@ -44,18 +44,19 @@ export class CareerController {
   @Get()
   @ApiOperation({
     summary: '경력 조회',
-    description: '언어별 경력 조회',
+    description: '언어별 경력을 조회합니다.',
   })
   @ApiResponse({
     status: 200,
     description: '경력 조회 성공',
     type: CareerResponseDto,
+    isArray: true,
   })
   @ApiResponse({ status: 404, description: '경력이 존재하지 않음' })
-  async findOneByLang(
+  async findByLang(
     @Query('lang') lang: LangType,
-  ): Promise<CareerResponseDto> {
-    return this.careerService.findOneByLang(lang);
+  ): Promise<CareerResponseDto[]> {
+    return this.careerService.findByLang(lang);
   }
 
   @Put(':key/:lang')


### PR DESCRIPTION
## 🔍 Overview

- Career 서비스에 toResponseDto 메서드 적용
- 경력 조회 API를 단일 → 목록 반환으로 변경

## ✅ What’s Included

- [x] Feature
- [x] Refactor

## 🔗 Related Issues

- Closes # (이슈가 있다면 번호 기입)

## 💬 Additional Notes

- 기존 단일 조회 테스트 제거, 목록 조회 테스트로 변경
