### PR TITLE
fix: 배포 파이프라인 main 브랜치 기준으로 수정 및 About 엔티티 컬럼 길이 확장

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no -i /tmp/my_key.pem ${{ secrets.SERVER_USERNAME }}@${{ secrets.SERVER_HOST }} << 'EOF'
             cd ~/apps/myungjoo-dev-be
-            git pull origin chore/deploy
+            git pull origin main
             docker compose down
             docker compose build
             docker compose up -d

--- a/src/modules/about/entities/about.entity.ts
+++ b/src/modules/about/entities/about.entity.ts
@@ -11,9 +11,9 @@ export class About {
   @Column({ type: 'varchar', length: 100 })
   menuKey: string;
 
-  @Column({ type: 'varchar', length: 500 })
+  @Column({ type: 'varchar', length: 1000 })
   content_ko: string;
 
-  @Column({ type: 'varchar', length: 500 })
+  @Column({ type: 'varchar', length: 1000 })
   content_en: string;
 }


### PR DESCRIPTION
## 🔍 Overview

- 배포 파이프라인에서 git pull 기준 브랜치를 main으로 수정
- About 엔티티의 content_ko, content_en 컬럼 길이를 500 → 1000으로 확장

## ✅ What’s Included

- [ ] Feature
- [x] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [x] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 🔗 Related Issues

- Closes # (해당 사항 없으면 비워두세요)

## 💬 Additional Notes

- 