### PR TITLE
feat: Career 조회 API key 배열 조건 및 startDate 내림차순 정렬 기능 추가

### DIFF
--- a/src/modules/career/career.controller.spec.ts
+++ b/src/modules/career/career.controller.spec.ts
@@ -149,8 +149,8 @@ describe('CareerController', () => {
 
   it('경력 조회 성공', async () => {
     (service.findByLang as jest.Mock).mockResolvedValue([mockCareerResponse]);
-    const result = await controller.findByLang('ko' as LangType);
+    const result = await controller.findByLang('ko' as LangType, 'supertree');
     expect(result).toEqual([mockCareerResponse]);
-    expect(service.findByLang).toHaveBeenCalledWith('ko');
+    expect(service.findByLang).toHaveBeenCalledWith('ko', ['supertree']);
   });
 });

--- a/src/modules/career/career.controller.ts
+++ b/src/modules/career/career.controller.ts
@@ -9,7 +9,13 @@ import {
   Query,
   Param,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 
 import { CareerService } from './career.service';
 import { CareerResponseDto } from './dto/career-response.dto';
@@ -46,6 +52,20 @@ export class CareerController {
     summary: '경력 조회',
     description: '언어별 경력을 조회합니다.',
   })
+  @ApiQuery({
+    name: 'lang',
+    required: true,
+    type: String,
+    description: '조회할 언어(ko, en)',
+  })
+  @ApiQuery({
+    name: 'key',
+    required: false,
+    type: String,
+    isArray: true,
+    description: '조회할 career key(복수 가능)',
+    example: ['supertree', 'ddive'],
+  })
   @ApiResponse({
     status: 200,
     description: '경력 조회 성공',
@@ -55,8 +75,11 @@ export class CareerController {
   @ApiResponse({ status: 404, description: '경력이 존재하지 않음' })
   async findByLang(
     @Query('lang') lang: LangType,
+    @Query('key') key: string | string[],
   ): Promise<CareerResponseDto[]> {
-    return this.careerService.findByLang(lang);
+    const keyArr: string[] | undefined =
+      typeof key === 'string' ? key.split(',') : key;
+    return this.careerService.findByLang(lang, keyArr);
   }
 
   @Put(':key/:lang')

--- a/src/modules/career/career.service.ts
+++ b/src/modules/career/career.service.ts
@@ -104,7 +104,7 @@ export class CareerService {
     key: string[],
   ): Promise<CareerResponseDto[]> {
     const found = await this.careerRepository.find({
-      where: { lang, key: key ? In(key) : undefined },
+      where: { lang, key: key && key.length > 0 ? In(key) : undefined },
       relations: ['projects'],
       order: { startDate: 'DESC' },
     });

--- a/src/modules/career/career.service.ts
+++ b/src/modules/career/career.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, In } from 'typeorm';
 
 import { CareerResponseDto } from './dto/career-response.dto';
 import {
@@ -99,10 +99,14 @@ export class CareerService {
     });
   }
 
-  async findByLang(lang: LangType): Promise<CareerResponseDto[]> {
+  async findByLang(
+    lang: LangType,
+    key: string[],
+  ): Promise<CareerResponseDto[]> {
     const found = await this.careerRepository.find({
-      where: { lang },
+      where: { lang, key: key ? In(key) : undefined },
       relations: ['projects'],
+      order: { startDate: 'DESC' },
     });
     if (!found || found.length === 0) {
       throw new CustomException(


### PR DESCRIPTION
## 🔍 Overview

- Career 조회 API(`GET /career`)에서 key(string[]) 배열 조건을 추가
- startDate 기준 내림차순 정렬이 적용되어 최신 경력이 먼저 조회되게끔 추가

## ✅ What’s Included

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 🔗 Related Issues

- Closes #21 

## 💬 Additional Notes

(추가로 전달할 내용이 있으면 작성, 없으면 비워두셔도 됩니다.)
