### PR TITLE
feat: career 조회 API에 all key값 추가

### DIFF
--- a/src/modules/career/career.service.ts
+++ b/src/modules/career/career.service.ts
@@ -101,20 +101,29 @@ export class CareerService {
 
   async findByLang(
     lang: LangType,
-    key: string[],
+    key: string[] = [],
   ): Promise<CareerResponseDto[]> {
+    if (key.length === 0) {
+      return [];
+    }
+
     const found = await this.careerRepository.find({
-      where: { lang, key: key && key.length > 0 ? In(key) : undefined },
+      where: {
+        lang,
+        ...(key.length > 0 && !key.includes('all') ? { key: In(key) } : {}),
+      },
       relations: ['projects'],
       order: { startDate: 'DESC' },
     });
+
     if (!found || found.length === 0) {
       throw new CustomException(
-        `lang '${lang}' does not exist.`,
+        `No data found for lang '${lang}'.`,
         ErrorCode.NOTFOUND_ERROR,
         { lang },
       );
     }
+
     return this.toResponseDto(found);
   }
 


### PR DESCRIPTION
## 🔍 Overview

<!-- Briefly describe what this PR does -->
- `career 조회 API`의 key값에 `all`을 추가하였고, `all`로 넘어올 경우에는 전체 데이터를 내보내도록 작업
- 추가로, key값이 없을 경우에는 빈배열([])을 내보내도록 작업

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Release
- [ ] Others (describe below)

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #27

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->
