### PR TITLE
feat: get career api의 name 응답 형식 수정

### DIFF
--- a/src/modules/career/dto/career-response.dto.ts
+++ b/src/modules/career/dto/career-response.dto.ts
@@ -34,8 +34,14 @@ export class CareerResponseDto {
   })
   lang: LangType;
 
-  @ApiProperty({ example: '㈜ 수퍼트리', description: '회사/경력 이름' })
-  name: string;
+  @ApiProperty({
+    example: { ko: '㈜ 수퍼트리', en: 'Supertree Corp.' },
+    description: '회사/경력 이름',
+  })
+  name: {
+    ko: string;
+    en: string;
+  };
 
   @ApiProperty({
     example:


### PR DESCRIPTION
## 🔍 Overview

<!-- Briefly describe what this PR does -->
- [GET] career API의 name 필드 응답 형식 변경
- 기존
```
"name": "(주) 수퍼트리"
```

- 변경
```
name: {
  "ko": "(주) 수퍼트리",
  "en": "Supertree Corp."
}
```

- 변경 이유는 다음과 같습니다.
  - Career 같은 경우는 Category API가 따로 존재하지 않음.
  - 프론트에서 사용 할 때 언어 변경이 되면 Career API를 다시 호출해서 메뉴 값들을 변경해주고 있음
  - 이때 react-query의 캐시값 때문에 초기 언어에 대한 이름이 화면에 남게됨.
  - 프론트에서 서버 사이드 호출을 포기하고, initial data를 안쓰고 하면 해결이 되겠으나, 초기 로딩속도 개선을 위해서 서버 사이드 호출을 포기 할 수는 없는 상황
  - 때문에 백엔드에서 ko, en 값을 한 번에 내려주고, 프론트에서는 받아서 처음에 받은 값을 가지고 ko, en 컨트롤을 할 예정. 

## ✅ What’s Included

<!-- Please check the relevant items below -->

- [x] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [ ] Code Refactor
- [ ] Test Code
- [ ] Release
- [ ] Others (describe below)

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->
